### PR TITLE
Add checkactions attribute to Checkbox widget

### DIFF
--- a/core/modules/widgets/checkbox.js
+++ b/core/modules/widgets/checkbox.js
@@ -156,6 +156,9 @@ CheckboxWidget.prototype.handleChangeEvent = function(event) {
 	if(this.checkboxActions) {
 		this.invokeActionString(this.checkboxActions,this,event);
 	}
+	if(this.checkboxCheckActions && checked) {
+		this.invokeActionString(this.checkboxCheckActions,this,event);
+	}
 	if(this.checkboxUncheckActions && !checked) {
 		this.invokeActionString(this.checkboxUncheckActions,this,event);
 	}
@@ -167,6 +170,7 @@ Compute the internal state of the widget
 CheckboxWidget.prototype.execute = function() {
 	// Get the parameters from the attributes
 	this.checkboxActions = this.getAttribute("actions");
+	this.checkboxCheckActions = this.getAttribute("checkactions");
 	this.checkboxUncheckActions = this.getAttribute("uncheckactions");
 	this.checkboxTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
 	this.checkboxTag = this.getAttribute("tag");

--- a/editions/tw5.com/tiddlers/widgets/CheckboxWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/CheckboxWidget.tid
@@ -1,6 +1,6 @@
 caption: checkbox
 created: 20131024141900000
-modified: 20161221202816730
+modified: 20190714134002652
 tags: Widgets
 title: CheckboxWidget
 type: text/vnd.tiddlywiki
@@ -26,8 +26,9 @@ The content of the `<$checkbox>` widget is displayed within an HTML `<label>` el
 |unchecked |The value of the field corresponding to the checkbox being unchecked |
 |default |The default value to use if the field is not defined |
 |class |The class that will be assigned to the label element |
-|actions |<<.from-version "5.1.14">> A string containing ActionWidgets to be triggered when the checkbox is checked |
+|actions |<<.from-version "5.1.14">> A string containing ActionWidgets to be triggered when the status of the checkbox changes (whether it is checked or unchecked) |
 |uncheckactions |<<.from-version "5.1.16">> A string containing ActionWidgets to be triggered when the checkbox is unchecked |
+|checkactions |<<.from-version "5.1.20">> A string containing ActionWidgets to be triggered when the checkbox is checked |
 
 !! Tag Mode
 


### PR DESCRIPTION
See discussion at https://groups.google.com/d/msgid/tiddlywiki/526754d5-8786-49cd-aaa1-c77311670116%40googlegroups.com:

The history here is that in v5.1.14 we added an "actions" attribute to the checkbox widget that specified an action string to be specified whenever the state of the checkbox changed. The same action string is executed regardless of whether the checkbox was checked or unchecked.

Then in v5.1.16 we merged https://github.com/Jermolene/TiddlyWiki5/pull/3182 which added the "uncheckactions" attribute. The difference between the two is that the uncheckactions are only executed if the checkbox is unchecked. The main "actions" attribute is executed before any actions in "uncheckactions", which makes it possible to arrange things so that the "actions" attribute sets things to the checked state while the "uncheckactions" attribute overwrites those changes to set things to the unchecked state.

In retrospect, it would have made more sense to have also added a "checkactions" attribute that was executed only if the checkbox was checked. I'll investigate adding it for v5.1.20.